### PR TITLE
Cleanup of launch file logic

### DIFF
--- a/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
+++ b/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
@@ -1,17 +1,15 @@
 <launch>
     <arg name="model"                        default="$(find victor_description)/urdf/victor.urdf.xacro"/>
     <arg name="arm_command_gui"              default="false"/>
-    <arg name="left_arm_recv_url_override"   default="false"/>
-    <arg name="right_arm_recv_url_override"  default="false"/>
-    <arg name="left_arm_recv_url"            if="$(arg left_arm_recv_url_override)"/>
-    <arg name="right_arm_recv_url"           if="$(arg right_arm_recv_url_override)"/>
+    <!-- Note that changing these from the default requires matching changes in the Java code -->
+    <arg name="left_arm_recv_url"            default="udp://10.10.10.10:30002"/>
+    <arg name="right_arm_recv_url"           default="udp://10.10.10.10:30001"/>
 
     <param name="robot_description" command="$(find xacro)/xacro --xacro-ns --inorder $(arg model)"/>
     <node pkg="victor_hardware_interface" type="joint_state_publisher.py" name="joint_state_publisher"/>
     <node pkg="robot_state_publisher"     type="robot_state_publisher"    name="robot_state_publisher"/>
     <node pkg="victor_hardware_interface" type="arm_command_gui.py"       name="arm_command_gui"    if="$(arg arm_command_gui)"/>
     
-
     <include file="$(find victor_hardware_interface)/launch/mocap_to_victor_static_transforms.launch">
         <arg name="use_sim_time" value="false"/>
     </include>
@@ -20,8 +18,7 @@
         <node pkg="victor_hardware_interface" type="victor_hardware_interface_arm_wrapper_node" name="left_arm_lcm_bridge_node" required="true" output="screen">
             <param name="cartesian_pose_frame"  type="string" value="victor_left_arm_world_frame_kuka"/>
             <param name="send_lcm_url"          type="string" value="udp://10.10.10.12:30000" />
-            <param name="recv_lcm_url"          type="string" value="udp://10.10.10.10:30002"   unless="$(arg left_arm_recv_url_override)"/>
-            <param name="recv_lcm_url"          type="string" value="$(arg left_arm_recv_url)"      if="$(arg left_arm_recv_url_override)"/>
+            <param name="recv_lcm_url"          type="string" value="$(arg left_arm_recv_url)"/>
         </node>
     </group>
 
@@ -29,8 +26,7 @@
         <node pkg="victor_hardware_interface" type="victor_hardware_interface_arm_wrapper_node" name="right_arm_lcm_bridge_node" required="true" output="screen">
             <param name="cartesian_pose_frame"  type="string" value="victor_right_arm_world_frame_kuka"/>
             <param name="send_lcm_url"          type="string" value="udp://10.10.10.11:30000"/>
-            <param name="recv_lcm_url"          type="string" value="udp://10.10.10.10:30001"   unless="$(arg right_arm_recv_url_override)"/>
-            <param name="recv_lcm_url"          type="string" value="$(arg right_arm_recv_url)"     if="$(arg right_arm_recv_url_override)"/>
+            <param name="recv_lcm_url"          type="string" value="$(arg right_arm_recv_url)"/>
         </node>
     </group>
 


### PR DESCRIPTION
Back when I wrote this I apparently thought that explicitly requiring an override parameter made things clearer. I don't think it does at this point, but I can't test this changed launch file on the robot right now.