### PR TITLE
Increased joint_relative_velocity limit in manual_motion.py. It was l…

### DIFF
--- a/victor_hardware_interface/scripts/manual_motion.py
+++ b/victor_hardware_interface/scripts/manual_motion.py
@@ -111,8 +111,11 @@ def print_joints(left, right):
 if __name__ == "__main__":
     rospy.init_node("manual_motion")
     print "initializing"
-    vu.set_control_mode(ControlMode.JOINT_IMPEDANCE, "left_arm", vu.Stiffness.MEDIUM)
-    vu.set_control_mode(ControlMode.JOINT_IMPEDANCE, "right_arm", vu.Stiffness.MEDIUM)
+    control_mode_params = vu.get_joint_impedance_params(vu.Stiffness.MEDIUM)
+    control_mode_params.joint_path_execution_params.joint_relative_velocity = 1.0
+    vu.send_new_control_mode("left_arm", control_mode_params)
+    vu.send_new_control_mode("right_arm", control_mode_params)
+
     left = ManualMotion("left_arm")
     right = ManualMotion("right_arm")
 


### PR DESCRIPTION
…imiting the speed at which victor could be pushed


@dmcconachie We talked about this. My low-pass filter does work, but there is an additional effective "low-pass" (ish) imposed by the Kuka Controller. Increasing the speed limit to 1 makes the robot much easier to push around. This will probably have merge conflicts with your open pull request.