### PR TITLE
Stop grippers on button release

### DIFF
--- a/victor_hardware_interface/scripts/xbox_control.py
+++ b/victor_hardware_interface/scripts/xbox_control.py
@@ -137,6 +137,9 @@ class VictorJoystick:
             cmd.scissor_command.position = cur.scissor_status.position_request
 
         self.gripper_command_publisher[gripper_name].publish(cmd)
+        self.gripper_status[gripper_name].get()
+        while not self.gripper_status[gripper_name].has_new_data():
+            rospy.sleep(0.01)
 
     def default_gripper_command(self):
         cmd = Robotiq3FingerCommand()


### PR DESCRIPTION
Now when releasing the xbox triggers the grippers stop where they are (instead of continuing to close/open)

Because of lag in the position publishing, they actually reverse direction for a bit.


This can be implemented for scissor control as well. 