### PR TITLE
Load planning context when starting Victor

### DIFF
--- a/victor_fake_hardware_interface/launch/fake_dual_arm_lcm_bridge.launch
+++ b/victor_fake_hardware_interface/launch/fake_dual_arm_lcm_bridge.launch
@@ -2,8 +2,12 @@
     <arg name="arm_command_gui"             default="false"/>
     <arg name="talkative"                   default="false"/>
 
+    <!-- Allows users to have slightly modified versions of Victor's URDF -->
+    <arg name="model"                       default="$(find victor_description)/urdf/victor.urdf.xacro"/>
+    <param name="robot_description"         command="$(find xacro)/xacro --xacro-ns --inorder $(arg model)"/>
+
     <include file="$(find victor_moveit_config)/launch/planning_context.launch">
-        <arg name="load_robot_description" value="true"/>
+        <arg name="load_robot_description" value="false"/>
     </include>
     <node pkg="victor_hardware_interface" type="joint_state_publisher.py" name="joint_state_publisher"/>
     <node pkg="robot_state_publisher"     type="robot_state_publisher"    name="robot_state_publisher"/>

--- a/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
+++ b/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
@@ -4,9 +4,13 @@
     <!-- Note that changing these from the default requires matching changes in the Java code -->
     <arg name="left_arm_recv_url"           default="udp://10.10.10.10:30002"/>
     <arg name="right_arm_recv_url"          default="udp://10.10.10.10:30001"/>
+    
+    <!-- Allows users to have slightly modified versions of Victor's URDF -->
+    <arg name="model"                       default="$(find victor_description)/urdf/victor.urdf.xacro"/>
+    <param name="robot_description"         command="$(find xacro)/xacro --xacro-ns --inorder $(arg model)"/>
 
     <include file="$(find victor_moveit_config)/launch/planning_context.launch">
-        <arg name="load_robot_description" value="true"/>
+        <arg name="load_robot_description" value="false"/>
     </include>
     <node pkg="victor_hardware_interface" type="joint_state_publisher.py" name="joint_state_publisher"/>
     <node pkg="robot_state_publisher"     type="robot_state_publisher"    name="robot_state_publisher"/>


### PR DESCRIPTION
Unless there is any particular reason not to, I'd like to load the MoveIt planning context when starting Victor.