### PR TITLE
Add a standalone gripper robot

### DIFF
--- a/victor_description/launch/visualize_gripper.launch
+++ b/victor_description/launch/visualize_gripper.launch
@@ -1,5 +1,5 @@
 <!-- Note: This is not the normal path of execution to launch Victor -->
-<!-- This create a "robot" from the robotiq 3 finger gripper. -->
+<!-- This creates a "robot" from the robotiq 3 finger gripper. -->
 <!-- This is useful for manually viewing the gripper in RViz when using something such as a grasp planner -->
 <!-- Place the gripper by publishing a transform from [baseframe] to [gripper_root]-->
 
@@ -9,20 +9,19 @@
         <arg name="model" default="$(find victor_description)/urdf/gripper_only.xacro"/>
         <arg name="joint_state_publisher" default="true"/>
         <arg name="gui" default="true"/>
-        <arg name="rviz" default="true"/>
+        <arg name="rviz" default="false"/>
         <arg name="set_default_robot_tf" default="true"/>
 
         <param name="robot_description" command="$(find xacro)/xacro $(arg model)"/>
-        <param name="use_gui" value="true"/>
+        <param name="use_gui" value="$(arg gui)"/>
 
         <node name="joint_state_publisher" pkg="joint_state_publisher"
               type="joint_state_publisher"/>
         <node name="gripper_target_joint_state_gui" pkg="joint_state_publisher_gui"
               type="joint_state_publisher_gui"/>
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
-<!--        <node pkg="tf" type="static_transform_publisher" name="mocap_to_robot_tf_publisher" args="0 0 0 0 0 0 1 mocap_world victor_root 100" if="$(arg set_default_robot_tf)"/>-->
 
-<!--        <node name="rviz" pkg="rviz" type="rviz" required="true" if="$(arg rviz)"/>-->
+        <node name="rviz" pkg="rviz" type="rviz" required="true" if="$(arg rviz)"/>
     </group>
 
 </launch>

--- a/victor_description/launch/visualize_gripper.launch
+++ b/victor_description/launch/visualize_gripper.launch
@@ -1,0 +1,29 @@
+<!-- Note: This is not the normal path of execution to launch Victor -->
+<!-- This create a "robot" from the robotiq 3 finger gripper. -->
+<!-- This is useful for manually viewing the gripper in RViz when using something such as a grasp planner -->
+<!-- Place the gripper by publishing a transform from [baseframe] to [gripper_root]-->
+
+<launch>
+
+    <group ns="gripper_visual">
+        <arg name="model" default="$(find victor_description)/urdf/gripper_only.xacro"/>
+        <arg name="joint_state_publisher" default="true"/>
+        <arg name="gui" default="true"/>
+        <arg name="rviz" default="true"/>
+        <arg name="set_default_robot_tf" default="true"/>
+
+        <param name="robot_description" command="$(find xacro)/xacro $(arg model)"/>
+        <param name="use_gui" value="true"/>
+
+        <node name="joint_state_publisher" pkg="joint_state_publisher"
+              type="joint_state_publisher"/>
+        <node name="gripper_target_joint_state_gui" pkg="joint_state_publisher_gui"
+              type="joint_state_publisher_gui"/>
+        <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+<!--        <node pkg="tf" type="static_transform_publisher" name="mocap_to_robot_tf_publisher" args="0 0 0 0 0 0 1 mocap_world victor_root 100" if="$(arg set_default_robot_tf)"/>-->
+
+<!--        <node name="rviz" pkg="rviz" type="rviz" required="true" if="$(arg rviz)"/>-->
+    </group>
+
+</launch>
+

--- a/victor_description/urdf/gripper_only.xacro
+++ b/victor_description/urdf/gripper_only.xacro
@@ -1,0 +1,21 @@
+<!-- Note: This is not the normal path of execution to launch Victor -->
+<!-- This creates a standalone robot from the 3_finger gripper -->
+
+<?xml version="1.0"?>
+<robot name="gripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:arg name="robot_name" default="gripper"/>
+
+        <!-- Import Rviz colors -->
+    <xacro:include filename="$(find victor_description)/urdf/materials.xacro"/>
+
+    <xacro:include filename="$(find victor_description)/urdf/utilities.xacro"/>
+
+    <link name="gripper_root"/>
+    <!-- Robotiq grippers -->
+    <!--Import the Robotiq 3 finger macro -->
+    <xacro:include filename="$(find victor_description)/urdf/robotiq_3finger_gripper.xacro"/>
+    <xacro:robotiq_3finger parent="gripper_root" prefix="gripper_visual">
+        <origin xyz="0 0 0.02705" rpy="0 0 ${PI/4}"/> <!-- Offset measured with a tape measure; please confirm/fix this value -->
+    </xacro:robotiq_3finger>
+
+</robot>

--- a/victor_description/urdf/gripper_only.xacro
+++ b/victor_description/urdf/gripper_only.xacro
@@ -5,14 +5,12 @@
 <robot name="gripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:arg name="robot_name" default="gripper"/>
 
-        <!-- Import Rviz colors -->
+    <!-- Import Rviz colors -->
     <xacro:include filename="$(find victor_description)/urdf/materials.xacro"/>
 
     <xacro:include filename="$(find victor_description)/urdf/utilities.xacro"/>
 
     <link name="gripper_root"/>
-    <!-- Robotiq grippers -->
-    <!--Import the Robotiq 3 finger macro -->
     <xacro:include filename="$(find victor_description)/urdf/robotiq_3finger_gripper.xacro"/>
     <xacro:robotiq_3finger parent="gripper_root" prefix="gripper_visual">
         <origin xyz="0 0 0.02705" rpy="0 0 ${PI/4}"/> <!-- Offset measured with a tape measure; please confirm/fix this value -->


### PR DESCRIPTION
I found this useful for viewing the gripper by itself in RViz.

I'd like to merge it in 
a) so my code works using the master branch of victor_hardware_interface
b) because maybe this will be useful for others


As a downside, it does clutter the repo with a second launch file