### PR TITLE
Removed --xacro-ns option, which no longer exists in noetic

### DIFF
--- a/victor_fake_hardware_interface/launch/fake_dual_arm_lcm_bridge.launch
+++ b/victor_fake_hardware_interface/launch/fake_dual_arm_lcm_bridge.launch
@@ -4,7 +4,7 @@
 
     <!-- Allows users to have slightly modified versions of Victor's URDF -->
     <arg name="model"                       default="$(find victor_description)/urdf/victor.urdf.xacro"/>
-    <param name="robot_description"         command="$(find xacro)/xacro --xacro-ns --inorder $(arg model)"/>
+    <param name="robot_description"         command="$(find xacro)/xacro --inorder $(arg model)"/>
 
     <include file="$(find victor_moveit_config)/launch/planning_context.launch">
         <arg name="load_robot_description" value="false"/>

--- a/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
+++ b/victor_hardware_interface/launch/dual_arm_lcm_bridge.launch
@@ -7,7 +7,7 @@
     
     <!-- Allows users to have slightly modified versions of Victor's URDF -->
     <arg name="model"                       default="$(find victor_description)/urdf/victor.urdf.xacro"/>
-    <param name="robot_description"         command="$(find xacro)/xacro --xacro-ns --inorder $(arg model)"/>
+    <param name="robot_description"         command="$(find xacro)/xacro --inorder $(arg model)"/>
 
     <include file="$(find victor_moveit_config)/launch/planning_context.launch">
         <arg name="load_robot_description" value="false"/>


### PR DESCRIPTION
I had errors with the `--xacro-ns` option for fake victor in noetic.

The `--xacro-ns` is needed to suppress legacy handling in ROS versions before Jade. We're not going to be using anything that old...ever
http://wiki.ros.org/xacro