### PR TITLE
Update command gui namespaces

### DIFF
--- a/victor_hardware_interface/scripts/arm_command_gui.py
+++ b/victor_hardware_interface/scripts/arm_command_gui.py
@@ -169,13 +169,13 @@ class Arm:
         self.finger_command.scissor_command.speed = 1.0
 
         self.finger_command_publisher = \
-            rospy.Publisher(self.name + '/gripper_command', Robotiq3FingerCommand, queue_size=10)
-        self.arm_command_publisher = rospy.Publisher(self.name + '/motion_command', MotionCommand, queue_size=10)
+            rospy.Publisher('victor/' + self.name + '/gripper_command', Robotiq3FingerCommand, queue_size=10)
+        self.arm_command_publisher = rospy.Publisher('victor/' + self.name + '/motion_command', MotionCommand, queue_size=10)
 
         self.gripper_status_subscriber = \
-            rospy.Subscriber(self.name + '/gripper_status', Robotiq3FingerStatus, self.gripper_status_callback)
+            rospy.Subscriber('victor/' + self.name + '/gripper_status', Robotiq3FingerStatus, self.gripper_status_callback)
         self.arm_status_subscriber = \
-            rospy.Subscriber(self.name + '/motion_status', MotionStatus, self.arm_status_callback)
+            rospy.Subscriber('victor/' + self.name + '/motion_status', MotionStatus, self.arm_status_callback)
 
         self.fingers_same_command = {finger_command_name: False for finger_command_name in finger_command_names}
 
@@ -195,7 +195,7 @@ class Arm:
 
         print('Getting {} current control mode ...'.format(self.name))
         sys.stdout.flush()
-        get_current_control_mode = rospy.ServiceProxy(self.name + '/get_control_mode_service', GetControlMode)
+        get_current_control_mode = rospy.ServiceProxy('victor/' + self.name + '/get_control_mode_service', GetControlMode)
         control_mode = get_current_control_mode()
         self.active_control_mode_int = control_mode.active_control_mode.control_mode.mode
         self.control_mode_combobox.setCurrentIndex(self.active_control_mode_int)

--- a/victor_hardware_interface/src/victor_hardware_interface/victor_utils.py
+++ b/victor_hardware_interface/src/victor_hardware_interface/victor_utils.py
@@ -44,7 +44,7 @@ def set_control_mode(control_mode, arm, stiffness=Stiffness.MEDIUM, vel=0.1, acc
 
 def send_new_control_mode(arm, msg):
     # TODO: Consider removing the forced global namespace in the future
-    send_new_control_mode_srv = rospy.ServiceProxy(arm + "/set_control_mode_service",
+    send_new_control_mode_srv = rospy.ServiceProxy("victor/" + arm + "/set_control_mode_service",
                                                    SetControlMode)
     return send_new_control_mode_srv(msg)
 


### PR DESCRIPTION
The arm command gui needed to be updated with the new "victor/" prefix.

1) Is there a better way to namespace these functions, given we will be launching via `rosrun victor_hardware_interface arm_command_gui.py`? I'm looking for setting the namespace in the `rospy.init` or similar.

2) There are probably other files that should be updated accordingly, but I have not searched. 