### PR TITLE
Fixed missed change from when msgs were moved to a separate package

### DIFF
--- a/victor_hardware_interface/CMakeLists.txt
+++ b/victor_hardware_interface/CMakeLists.txt
@@ -131,3 +131,6 @@ target_link_libraries(${PROJECT_NAME}_loopback_test_node ${PROJECT_NAME} ${catki
 add_executable(${PROJECT_NAME}_arm_wrapper_node src/arm_wrapper_node.cpp)
 add_dependencies(${PROJECT_NAME}_arm_wrapper_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_arm_wrapper_node ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+
+catkin_add_gtest(test_victor_utils tests/test_victor_utils.cpp)

--- a/victor_hardware_interface/include/victor_hardware_interface/victor_utils.hpp
+++ b/victor_hardware_interface/include/victor_hardware_interface/victor_utils.hpp
@@ -6,16 +6,16 @@
  */
 
 
-#include <victor_hardware_interface/JointValueQuantity.h>
+#include <victor_hardware_interface_msgs/JointValueQuantity.h>
 
 namespace victor_utils
 {
-    static victor_hardware_interface::JointValueQuantity vectorToJvq(const std::vector<double> &v)
+    static victor_hardware_interface_msgs::JointValueQuantity vectorToJvq(const std::vector<double> &v)
     {
         assert(v.size() == 7);
         
-        victor_hardware_interface::JointValueQuantity jvq;
-        jvq = victor_hardware_interface::JointValueQuantity();
+        victor_hardware_interface_msgs::JointValueQuantity jvq;
+        jvq = victor_hardware_interface_msgs::JointValueQuantity();
         jvq.joint_1 = v[0];
         jvq.joint_2 = v[1];
         jvq.joint_3 = v[2];
@@ -26,7 +26,7 @@ namespace victor_utils
         return jvq;
     };
 
-    static std::vector<double> jvqToVector(const victor_hardware_interface::JointValueQuantity &jvq)
+    static std::vector<double> jvqToVector(const victor_hardware_interface_msgs::JointValueQuantity &jvq)
     {
         std::vector<double> v(7);
         v[0] = jvq.joint_1;

--- a/victor_hardware_interface/tests/test_victor_utils.cpp
+++ b/victor_hardware_interface/tests/test_victor_utils.cpp
@@ -1,0 +1,16 @@
+#include "victor_hardware_interface/victor_utils.hpp"
+#include <gtest/gtest.h>
+
+
+TEST(VictorUtils, conversion_from_and_to_jvq_does_not_change)
+{
+  using namespace victor_utils;
+  std::vector<double> v{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7};
+  EXPECT_EQ(v, jvqToVector(vectorToJvq(v)));
+}
+
+
+GTEST_API_ int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/victor_hardware_interface/tests/victor_utils_test.py
+++ b/victor_hardware_interface/tests/victor_utils_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import unittest
-import IPython
 from victor_hardware_interface import victor_utils as vu
 
 


### PR DESCRIPTION
Also wrote a unit test so this change would have been caught.

I guess no one is using this code. I only caught this when building my VR teleop