### PR TITLE
Organization

### DIFF
--- a/victor_moveit_config/config/victor.srdf
+++ b/victor_moveit_config/config/victor.srdf
@@ -102,6 +102,22 @@
         <joint name="victor_right_arm_joint_6" value="-1.331"/>
         <joint name="victor_right_arm_joint_7" value="-2.261"/>
     </group_state>
+    <group_state name="impedance_switch" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="-0.694"/>
+        <joint name="victor_left_arm_joint_2" value="0.140"/>
+        <joint name="victor_left_arm_joint_3" value="-0.229"/>
+        <joint name="victor_left_arm_joint_4" value="-1.110"/>
+        <joint name="victor_left_arm_joint_5" value="-0.512"/>
+        <joint name="victor_left_arm_joint_6" value="1.272"/>
+        <joint name="victor_left_arm_joint_7" value="0.077"/>
+        <joint name="victor_right_arm_joint_1" value="0.724"/>
+        <joint name="victor_right_arm_joint_2" value="0.451"/>
+        <joint name="victor_right_arm_joint_3" value="0.940"/>
+        <joint name="victor_right_arm_joint_4" value="-1.425"/>
+        <joint name="victor_right_arm_joint_5" value="0.472"/>
+        <joint name="victor_right_arm_joint_6" value="0.777"/>
+        <joint name="victor_right_arm_joint_7" value="-0.809"/>
+    </group_state>
 
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="right_ee" parent_link="victor_right_arm_flange" group="right_gripper"/>

--- a/victor_moveit_config/config/victor.srdf
+++ b/victor_moveit_config/config/victor.srdf
@@ -86,6 +86,23 @@
         <joint name="victor_left_arm_joint_6" value="0"/>
         <joint name="victor_left_arm_joint_7" value="0"/>
     </group_state>
+    <group_state name="up_and_back" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="-2.017"/>
+        <joint name="victor_left_arm_joint_2" value="1.141"/>
+        <joint name="victor_left_arm_joint_3" value="-0.737"/>
+        <joint name="victor_left_arm_joint_4" value="-1.319"/>
+        <joint name="victor_left_arm_joint_5" value="0.703"/>
+        <joint name="victor_left_arm_joint_6" value="1.534"/>
+        <joint name="victor_left_arm_joint_7" value="1.153"/>
+        <joint name="victor_right_arm_joint_1" value="-0.972"/>
+        <joint name="victor_right_arm_joint_2" value="-1.558"/>
+        <joint name="victor_right_arm_joint_3" value="0.505"/>
+        <joint name="victor_right_arm_joint_4" value="1.552"/>
+        <joint name="victor_right_arm_joint_5" value="-1.765"/>
+        <joint name="victor_right_arm_joint_6" value="-1.331"/>
+        <joint name="victor_right_arm_joint_7" value="-2.261"/>
+    </group_state>
+
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="right_ee" parent_link="victor_right_arm_flange" group="right_gripper"/>
     <end_effector name="left_ee" parent_link="victor_left_arm_flange" group="left_gripper"/>

--- a/victor_moveit_config/config/victor.srdf
+++ b/victor_moveit_config/config/victor.srdf
@@ -51,7 +51,17 @@
         <group name="left_arm"/>
         <group name="right_arm"/>
     </group>
-    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+
+
+    <!-- ---------------------------------------- -->
+    <!---           NAMED Positions           -->
+    <!-- ---------------------------------------- -->
+
+
+    <!-- GROUP STATES: Purpose: Define a named state for a -->
+    <!-- particular group, in terms of joint values. This -->
+    <!-- is useful to define states like 'folded arms'--> 
+
     <group_state name="right_arm_zero" group="right_arm">
         <joint name="victor_right_arm_joint_1" value="0"/>
         <joint name="victor_right_arm_joint_2" value="0"/>
@@ -118,6 +128,85 @@
         <joint name="victor_right_arm_joint_6" value="0.777"/>
         <joint name="victor_right_arm_joint_7" value="-0.809"/>
     </group_state>
+    <group_state name="hug" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="0.604"/>
+        <joint name="victor_left_arm_joint_2" value="1.568"/>
+        <joint name="victor_left_arm_joint_3" value="-0.021"/>
+        <joint name="victor_left_arm_joint_4" value="-1.164"/>
+        <joint name="victor_left_arm_joint_5" value="0.355"/>
+        <joint name="victor_left_arm_joint_6" value="0.173"/>
+        <joint name="victor_left_arm_joint_7" value="0.297"/>
+        <joint name="victor_right_arm_joint_1" value="0.311"/>
+        <joint name="victor_right_arm_joint_2" value="1.561"/>
+        <joint name="victor_right_arm_joint_3" value="0.282"/>
+        <joint name="victor_right_arm_joint_4" value="-1.296"/>
+        <joint name="victor_right_arm_joint_5" value="0.137"/>
+        <joint name="victor_right_arm_joint_6" value="0.493"/>
+        <joint name="victor_right_arm_joint_7" value="0.112"/>
+    </group_state>
+    <group_state name="straight_up" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="-1.566"/>
+        <joint name="victor_left_arm_joint_2" value="1.570"/>
+        <joint name="victor_left_arm_joint_3" value="-0.002"/>
+        <joint name="victor_left_arm_joint_4" value="0.000"/>
+        <joint name="victor_left_arm_joint_5" value="0.002"/>
+        <joint name="victor_left_arm_joint_6" value="-0.001"/>
+        <joint name="victor_left_arm_joint_7" value="-0.000"/>
+        <joint name="victor_right_arm_joint_1" value="1.565"/>
+        <joint name="victor_right_arm_joint_2" value="1.568"/>
+        <joint name="victor_right_arm_joint_3" value="-0.002"/>
+        <joint name="victor_right_arm_joint_4" value="-0.001"/>
+        <joint name="victor_right_arm_joint_5" value="0.003"/>
+        <joint name="victor_right_arm_joint_6" value="-0.001"/>
+        <joint name="victor_right_arm_joint_7" value="0.001"/>
+    </group_state>
+    <group_state name="at_side" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="-1.270"/>
+        <joint name="victor_left_arm_joint_2" value="-1.227"/>
+        <joint name="victor_left_arm_joint_3" value="-0.309"/>
+        <joint name="victor_left_arm_joint_4" value="0.360"/>
+        <joint name="victor_left_arm_joint_5" value="-0.585"/>
+        <joint name="victor_left_arm_joint_6" value="0.496"/>
+        <joint name="victor_left_arm_joint_7" value="0.105"/>
+        <joint name="victor_right_arm_joint_1" value="1.144"/>
+        <joint name="victor_right_arm_joint_2" value="-1.189"/>
+        <joint name="victor_right_arm_joint_3" value="0.590"/>
+        <joint name="victor_right_arm_joint_4" value="0.292"/>
+        <joint name="victor_right_arm_joint_5" value="0.296"/>
+        <joint name="victor_right_arm_joint_6" value="0.265"/>
+        <joint name="victor_right_arm_joint_7" value="-0.809"/>
+    </group_state>
+    <group_state name="flex" group="both_arms">
+        <joint name="victor_left_arm_joint_1" value="-0.229"/>
+        <joint name="victor_left_arm_joint_2" value="-0.122"/>
+        <joint name="victor_left_arm_joint_3" value="-1.215"/>
+        <joint name="victor_left_arm_joint_4" value="-1.562"/>
+        <joint name="victor_left_arm_joint_5" value="-0.227"/>
+        <joint name="victor_left_arm_joint_6" value="1.572"/>
+        <joint name="victor_left_arm_joint_7" value="-0.119"/>
+        <joint name="victor_right_arm_joint_1" value="1.247"/>
+        <joint name="victor_right_arm_joint_2" value="-0.751"/>
+        <joint name="victor_right_arm_joint_3" value="1.119"/>
+        <joint name="victor_right_arm_joint_4" value="1.401"/>
+        <joint name="victor_right_arm_joint_5" value="0.281"/>
+        <joint name="victor_right_arm_joint_6" value="-1.382"/>
+        <joint name="victor_right_arm_joint_7" value="-1.069"/>
+    </group_state>
+    <group_state name="handshake" group="right_arm">
+        <joint name="victor_right_arm_joint_1" value="-0.336"/>
+        <joint name="victor_right_arm_joint_2" value="0.105"/>
+        <joint name="victor_right_arm_joint_3" value="0.061"/>
+        <joint name="victor_right_arm_joint_4" value="-1.151"/>
+        <joint name="victor_right_arm_joint_5" value="-0.010"/>
+        <joint name="victor_right_arm_joint_6" value="0.577"/>
+        <joint name="victor_right_arm_joint_7" value="-0.675"/>
+    </group_state>
+
+
+    <!-- ---------------------------------------- -->
+    <!---           END Named Positions           -->
+    <!-- ---------------------------------------- -->
+
 
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="right_ee" parent_link="victor_right_arm_flange" group="right_gripper"/>


### PR DESCRIPTION
Addresses: https://github.com/UM-ARM-Lab/kuka_iiwa_interface/issues/134

There will be a corresponding change in `arm_robots`
You can test these in viz by launching `roslaunch arm_robots rviz_victor launch_fake_dual_arm_bridge:=true`
Then opening rviz with the `victor.rviz` file from `arm_robots`